### PR TITLE
パッケージ名に project_ を付与する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # What
 
-* 
+* サブプロジェクト上にあるシーンの読み込みをサポートします
+* シーンがビルドに含まれているのか AssetBundle による Streamed なのかを問わず読み込みを可能にします
 
 # Why
 
-* 
+* 通常の `UnityEngine.SceneManagement.SceneManager.LoadScene()` では AssetBundle の事前読み込みをサポートしていません
+* また、サブプロジェクト化されたプロジェクトのシーンを読み込む際に [`@umm/project_assetbundle_loader`](https://github.com/umm-projects/project_assetbundle_loader) を用いる必要があるため、ラッパーを実装します
 
 # Requirement
 
-* 
+* Unity 2017.1
 
 # Install
 
 ```shell
-$ npm install github:umm-projects/scene_loader
+$ npm install github:umm-projects/project_scene_loader
 ```
 
 # Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@umm/scene_loader",
+  "name": "@umm/project_scene_loader",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@umm/scene_loader",
+  "name": "@umm/project_scene_loader",
   "version": "1.0.0",
   "description": "Scene loader supports divided projects.",
-  "homepage": "https://github.com/umm-projects/scene_loader",
+  "homepage": "https://github.com/umm-projects/project_scene_loader",
   "bugs": {
-    "url": "https://github.com/umm-projects/scene_loader/issues"
+    "url": "https://github.com/umm-projects/project_scene_loader/issues"
   },
   "scripts": {
     "umm:init": "./scripts/umm/init",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:umm-projects/scene_loader"
+    "url": "git@github.com:umm-projects/project_scene_loader"
   },
   "files": [
     "Assets",


### PR DESCRIPTION
* 通常の SceneManager との混同を避けるために、 `project_` プレフィックスを付与します